### PR TITLE
Updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
+node_modules
 /.pnp
 .pnp.js
 


### PR DESCRIPTION
Remove the slash bar in front of node_modules in gitignore that led to the repository adding 37000 files.